### PR TITLE
Enable explicit API mode and update library for it

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,7 +7,7 @@
     <option name="SOFT_MARGINS" value="100" />
     <option name="DO_NOT_FORMAT">
       <list>
-        <fileSet type="namedScope" name="publicsuffixlist" pattern="src[app]:mozilla.components.lib.publicsuffixlist.PublicSuffixList||src[app]:mozilla.components.lib.publicsuffixlist.PublicSuffixListData||src[app]:mozilla.components.lib.publicsuffixlist.PublicSuffixListLoader||src[app]:mozilla.components.lib.publicsuffixlist.ext.ByteArray" />
+        <fileSet type="namedScope" name="third_party" pattern="src[Android-Password-Store.app]:mozilla.components.lib.publicsuffixlist..*" />
       </list>
     </option>
     <JavaCodeStyleSettings>
@@ -16,6 +16,23 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value />
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="android" alias="false" withSubpackages="true" />
+          <package name="androidx" alias="false" withSubpackages="true" />
+          <package name="com" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="kotlinx" alias="false" withSubpackages="true" />
+          <package name="me" alias="false" withSubpackages="true" />
+          <package name="mozilla" alias="false" withSubpackages="true" />
+          <package name="net" alias="false" withSubpackages="true" />
+          <package name="org" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -33,6 +33,14 @@ android {
     defaultConfig {
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
+
+    kotlin.explicitApi = 'strict'
+
+    kotlinOptions {
+      freeCompilerArgs += [
+          '-Xexplicit-api=strict',
+      ]
+    }
 }
 
 afterEvaluate {

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
@@ -10,6 +10,7 @@ import android.os.Parcelable.Creator
 import java.util.Date
 
 public class AutocryptPeerUpdate() : Parcelable {
+
     private var keyData: ByteArray? = null
     private var effectiveDate: Date? = null
     private lateinit var preferEncrypt: PreferEncrypt
@@ -85,6 +86,7 @@ public class AutocryptPeerUpdate() : Parcelable {
     }
 
     internal companion object CREATOR : Creator<AutocryptPeerUpdate> {
+
         private const val PARCELABLE_VERSION = 1
         override fun createFromParcel(source: Parcel): AutocryptPeerUpdate? {
             val version = source.readInt() // parcelableVersion

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
@@ -9,12 +9,12 @@ import android.os.Parcelable
 import android.os.Parcelable.Creator
 import java.util.Date
 
-class AutocryptPeerUpdate() : Parcelable {
+public class AutocryptPeerUpdate() : Parcelable {
     private var keyData: ByteArray? = null
     private var effectiveDate: Date? = null
     private lateinit var preferEncrypt: PreferEncrypt
 
-    private constructor(
+    internal constructor(
         keyData: ByteArray?,
         effectiveDate: Date?,
         preferEncrypt: PreferEncrypt
@@ -30,26 +30,26 @@ class AutocryptPeerUpdate() : Parcelable {
         preferEncrypt = PreferEncrypt.values()[source.readInt()]
     }
 
-    fun createAutocryptPeerUpdate(
+    public fun createAutocryptPeerUpdate(
         keyData: ByteArray?,
         timestamp: Date?
     ): AutocryptPeerUpdate {
         return AutocryptPeerUpdate(keyData, timestamp, PreferEncrypt.NOPREFERENCE)
     }
 
-    fun getKeyData(): ByteArray? {
+    public fun getKeyData(): ByteArray? {
         return keyData
     }
 
-    fun hasKeyData(): Boolean {
+    public fun hasKeyData(): Boolean {
         return keyData != null
     }
 
-    fun getEffectiveDate(): Date? {
+    public fun getEffectiveDate(): Date? {
         return effectiveDate
     }
 
-    fun getPreferEncrypt(): PreferEncrypt? {
+    public fun getPreferEncrypt(): PreferEncrypt? {
         return preferEncrypt
     }
 
@@ -84,7 +84,7 @@ class AutocryptPeerUpdate() : Parcelable {
         dest.setDataPosition(startPosition + parcelableSize)
     }
 
-    companion object CREATOR : Creator<AutocryptPeerUpdate> {
+    internal companion object CREATOR : Creator<AutocryptPeerUpdate> {
         private const val PARCELABLE_VERSION = 1
         override fun createFromParcel(source: Parcel): AutocryptPeerUpdate? {
             val version = source.readInt() // parcelableVersion
@@ -101,7 +101,7 @@ class AutocryptPeerUpdate() : Parcelable {
         }
     }
 
-    enum class PreferEncrypt {
+    public enum class PreferEncrypt {
         NOPREFERENCE, MUTUAL
     }
 }

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/AutocryptPeerUpdate.kt
@@ -85,7 +85,7 @@ public class AutocryptPeerUpdate() : Parcelable {
         dest.setDataPosition(startPosition + parcelableSize)
     }
 
-    internal companion object CREATOR : Creator<AutocryptPeerUpdate> {
+    public companion object CREATOR : Creator<AutocryptPeerUpdate> {
 
         private const val PARCELABLE_VERSION = 1
         override fun createFromParcel(source: Parcel): AutocryptPeerUpdate? {

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/model/OpenPgpProviderEntry.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/model/OpenPgpProviderEntry.kt
@@ -13,5 +13,6 @@ internal data class OpenPgpProviderEntry(
     val icon: Drawable? = null,
     val intent: Intent? = null
 ) {
+
     override fun toString(): String = simpleName
 }

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/model/OpenPgpProviderEntry.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/model/OpenPgpProviderEntry.kt
@@ -7,7 +7,7 @@ package me.msfjarvis.openpgpktx.model
 import android.content.Intent
 import android.graphics.drawable.Drawable
 
-data class OpenPgpProviderEntry(
+internal data class OpenPgpProviderEntry(
     val packageName: String,
     val simpleName: String,
     val icon: Drawable? = null,

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpAppPreference.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpAppPreference.kt
@@ -14,7 +14,7 @@ import me.msfjarvis.openpgpktx.R
 import me.msfjarvis.openpgpktx.util.ProviderUtils
 import me.msfjarvis.openpgpktx.util.getAttr
 
-class OpenPgpAppPreference @JvmOverloads constructor(
+public class OpenPgpAppPreference @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = getAttr(

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpAppPreference.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpAppPreference.kt
@@ -24,6 +24,7 @@ public class OpenPgpAppPreference @JvmOverloads constructor(
     ),
     defStyleRes: Int = 0
 ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
+
     private val apps = ProviderUtils.getAppList(context)
     private val defaultName = context.resources.getString(R.string.openpgp_list_preference_none)
 

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpKeyPreference.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpKeyPreference.kt
@@ -30,20 +30,20 @@ import me.msfjarvis.openpgpktx.util.getAttr
 import org.openintents.openpgp.IOpenPgpService2
 import org.openintents.openpgp.OpenPgpError
 
-class OpenPgpKeyPreference @JvmOverloads constructor(
+public class OpenPgpKeyPreference @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = getAttr(context, R.attr.preferenceStyle, android.R.attr.preferenceStyle),
     defStyleRes: Int = 0
 ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
     private var keyId: Long = 0
-    var openPgpProvider: String? = null
+    private var openPgpProvider: String? = null
         set(value) {
             field = value
             updateEnabled()
         }
-    var defaultUserId: String? = null
-    var intentRequestCode = 9999
+    private var defaultUserId: String? = null
+    private var intentRequestCode = 9999
     private var serviceConnection: OpenPgpServiceConnection? = null
 
     override fun getSummary(): CharSequence? {
@@ -123,17 +123,11 @@ class OpenPgpKeyPreference @JvmOverloads constructor(
         setAndPersist(newValue)
     }
 
-    /**
-     * Public API
-     */
-    fun setValue(keyId: Long) {
+    public fun setValue(keyId: Long) {
         setAndPersist(keyId)
     }
 
-    /**
-     * Public API
-     */
-    fun getValue(): Long {
+    public fun getValue(): Long {
         return keyId
     }
 
@@ -198,7 +192,7 @@ class OpenPgpKeyPreference @JvmOverloads constructor(
         notifyChanged()
     }
 
-    fun handleOnActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+    public fun handleOnActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
         return if (requestCode == intentRequestCode && resultCode == Activity.RESULT_OK) {
             getSignKeyId(data)
             true
@@ -207,7 +201,7 @@ class OpenPgpKeyPreference @JvmOverloads constructor(
         }
     }
 
-    companion object {
+    private companion object {
         private const val NO_KEY = 0L
         private const val TAG = "OpenPgpKeyPreference"
     }
@@ -219,7 +213,7 @@ class OpenPgpKeyPreference @JvmOverloads constructor(
      *
      * It is important to always call through to super methods.
      */
-    class SavedState : BaseSavedState {
+    internal class SavedState : BaseSavedState {
         internal var keyId: Long = 0
         internal var openPgpProvider: String? = null
         internal var defaultUserId: String? = null

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpKeyPreference.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpKeyPreference.kt
@@ -38,13 +38,13 @@ public class OpenPgpKeyPreference @JvmOverloads constructor(
 ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
 
     private var keyId: Long = 0
-    private var openPgpProvider: String? = null
+    public var openPgpProvider: String? = null
         set(value) {
             field = value
             updateEnabled()
         }
-    private var defaultUserId: String? = null
-    private var intentRequestCode = 9999
+    public var defaultUserId: String? = null
+    public var intentRequestCode: Int = 9999
     private var serviceConnection: OpenPgpServiceConnection? = null
 
     override fun getSummary(): CharSequence? {

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpKeyPreference.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/preference/OpenPgpKeyPreference.kt
@@ -36,6 +36,7 @@ public class OpenPgpKeyPreference @JvmOverloads constructor(
     defStyleAttr: Int = getAttr(context, R.attr.preferenceStyle, android.R.attr.preferenceStyle),
     defStyleRes: Int = 0
 ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
+
     private var keyId: Long = 0
     private var openPgpProvider: String? = null
         set(value) {
@@ -202,6 +203,7 @@ public class OpenPgpKeyPreference @JvmOverloads constructor(
     }
 
     private companion object {
+
         private const val NO_KEY = 0L
         private const val TAG = "OpenPgpKeyPreference"
     }
@@ -214,6 +216,7 @@ public class OpenPgpKeyPreference @JvmOverloads constructor(
      * It is important to always call through to super methods.
      */
     internal class SavedState : BaseSavedState {
+
         internal var keyId: Long = 0
         internal var openPgpProvider: String? = null
         internal var defaultUserId: String? = null
@@ -234,6 +237,7 @@ public class OpenPgpKeyPreference @JvmOverloads constructor(
         constructor(superState: Parcelable?) : super(superState)
 
         companion object CREATOR : Creator<SavedState> {
+
             override fun createFromParcel(`in`: Parcel): SavedState? {
                 return SavedState(`in`)
             }

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpApi.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpApi.kt
@@ -10,14 +10,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.ParcelFileDescriptor
 import android.util.Log
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import org.openintents.openpgp.IOpenPgpService2
-import org.openintents.openpgp.OpenPgpError
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.openintents.openpgp.IOpenPgpService2
+import org.openintents.openpgp.OpenPgpError
 
 public class OpenPgpApi(private val context: Context, private val service: IOpenPgpService2) {
 
@@ -119,6 +119,7 @@ public class OpenPgpApi(private val context: Context, private val service: IOpen
     }
 
     public companion object {
+
         private const val TAG = "OpenPgp API"
 
         public const val SERVICE_INTENT_2: String = "org.openintents.openpgp.IOpenPgpService2"

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpApi.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpApi.kt
@@ -19,11 +19,11 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.atomic.AtomicInteger
 
-class OpenPgpApi(private val context: Context, private val service: IOpenPgpService2) {
+public class OpenPgpApi(private val context: Context, private val service: IOpenPgpService2) {
 
     private val pipeIdGen: AtomicInteger = AtomicInteger()
 
-    suspend fun executeApiAsync(
+    public suspend fun executeApiAsync(
         data: Intent?,
         inputStream: InputStream?,
         outputStream: OutputStream?,
@@ -35,7 +35,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
         }
     }
 
-    fun executeApi(data: Intent?, inputStream: InputStream?, outputStream: OutputStream?): Intent? {
+    public fun executeApi(data: Intent?, inputStream: InputStream?, outputStream: OutputStream?): Intent? {
         var input: ParcelFileDescriptor? = null
         return try {
             if (inputStream != null) {
@@ -118,15 +118,15 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
         }
     }
 
-    companion object {
-        const val TAG = "OpenPgp API"
+    public companion object {
+        private const val TAG = "OpenPgp API"
 
-        const val SERVICE_INTENT_2 = "org.openintents.openpgp.IOpenPgpService2"
+        public const val SERVICE_INTENT_2: String = "org.openintents.openpgp.IOpenPgpService2"
 
         /**
          * see CHANGELOG.md
          */
-        const val API_VERSION = 11
+        public const val API_VERSION: Int = 11
 
         /**
          * General extras
@@ -160,7 +160,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          *
          * This action uses no extras.
          */
-        const val ACTION_CHECK_PERMISSION = "org.openintents.openpgp.action.CHECK_PERMISSION"
+        public const val ACTION_CHECK_PERMISSION: String = "org.openintents.openpgp.action.CHECK_PERMISSION"
 
         /**
          * Sign text resulting in a cleartext signature
@@ -175,7 +175,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * optional extras:
          * char[]        EXTRA_PASSPHRASE            (key passphrase)
          */
-        const val ACTION_CLEARTEXT_SIGN = "org.openintents.openpgp.action.CLEARTEXT_SIGN"
+        public const val ACTION_CLEARTEXT_SIGN: String = "org.openintents.openpgp.action.CLEARTEXT_SIGN"
 
         /**
          * Sign text or binary data resulting in a detached signature.
@@ -193,7 +193,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * byte[]        RESULT_DETACHED_SIGNATURE
          * String        RESULT_SIGNATURE_MICALG     (contains the name of the used signature algorithm as a string)
          */
-        const val ACTION_DETACHED_SIGN = "org.openintents.openpgp.action.DETACHED_SIGN"
+        public const val ACTION_DETACHED_SIGN: String = "org.openintents.openpgp.action.DETACHED_SIGN"
 
         /**
          * Encrypt
@@ -209,7 +209,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * String        EXTRA_ORIGINAL_FILENAME     (original filename to be encrypted as metadata)
          * boolean       EXTRA_ENABLE_COMPRESSION    (enable ZLIB compression, default ist true)
          */
-        const val ACTION_ENCRYPT = "org.openintents.openpgp.action.ENCRYPT"
+        public const val ACTION_ENCRYPT: String = "org.openintents.openpgp.action.ENCRYPT"
 
         /**
          * Sign and encrypt
@@ -226,9 +226,9 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * String        EXTRA_ORIGINAL_FILENAME     (original filename to be encrypted as metadata)
          * boolean       EXTRA_ENABLE_COMPRESSION    (enable ZLIB compression, default ist true)
          */
-        const val ACTION_SIGN_AND_ENCRYPT = "org.openintents.openpgp.action.SIGN_AND_ENCRYPT"
+        public const val ACTION_SIGN_AND_ENCRYPT: String = "org.openintents.openpgp.action.SIGN_AND_ENCRYPT"
 
-        const val ACTION_QUERY_AUTOCRYPT_STATUS =
+        public const val ACTION_QUERY_AUTOCRYPT_STATUS: String =
             "org.openintents.openpgp.action.QUERY_AUTOCRYPT_STATUS"
 
         /**
@@ -250,7 +250,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * OpenPgpDecryptMetadata   RESULT_METADATA
          * String                   RESULT_CHARSET   (charset which was specified in the headers of ascii armored input, if any)
          */
-        const val ACTION_DECRYPT_VERIFY = "org.openintents.openpgp.action.DECRYPT_VERIFY"
+        public const val ACTION_DECRYPT_VERIFY: String = "org.openintents.openpgp.action.DECRYPT_VERIFY"
 
         /**
          * Decrypts the header of an encrypted file to retrieve metadata such as original filename.
@@ -261,7 +261,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * OpenPgpDecryptMetadata   RESULT_METADATA
          * String                   RESULT_CHARSET   (charset which was specified in the headers of ascii armored input, if any)
          */
-        const val ACTION_DECRYPT_METADATA = "org.openintents.openpgp.action.DECRYPT_METADATA"
+        public const val ACTION_DECRYPT_METADATA: String = "org.openintents.openpgp.action.DECRYPT_METADATA"
 
         /**
          * Select key id for signing
@@ -272,7 +272,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * returned extras:
          * long        EXTRA_SIGN_KEY_ID
          */
-        const val ACTION_GET_SIGN_KEY_ID = "org.openintents.openpgp.action.GET_SIGN_KEY_ID"
+        public const val ACTION_GET_SIGN_KEY_ID: String = "org.openintents.openpgp.action.GET_SIGN_KEY_ID"
 
         /**
          * Get key ids based on given user ids (=emails)
@@ -283,7 +283,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * returned extras:
          * long[]        RESULT_KEY_IDS
          */
-        const val ACTION_GET_KEY_IDS = "org.openintents.openpgp.action.GET_KEY_IDS"
+        public const val ACTION_GET_KEY_IDS: String = "org.openintents.openpgp.action.GET_KEY_IDS"
 
         /**
          * This action returns RESULT_CODE_SUCCESS if the OpenPGP Provider already has the key
@@ -299,7 +299,7 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * optional extras:
          * String      EXTRA_REQUEST_ASCII_ARMOR (request that the returned key is encoded in ASCII Armor)
          */
-        const val ACTION_GET_KEY = "org.openintents.openpgp.action.GET_KEY"
+        public const val ACTION_GET_KEY: String = "org.openintents.openpgp.action.GET_KEY"
 
         /**
          * Backup all keys given by EXTRA_KEY_IDS and if requested their secret parts.
@@ -311,91 +311,91 @@ class OpenPgpApi(private val context: Context, private val service: IOpenPgpServ
          * long[]      EXTRA_KEY_IDS       (keys that should be included in the backup)
          * boolean     EXTRA_BACKUP_SECRET (also backup secret keys)
          */
-        const val ACTION_BACKUP = "org.openintents.openpgp.action.BACKUP"
+        public const val ACTION_BACKUP: String = "org.openintents.openpgp.action.BACKUP"
 
-        const val ACTION_UPDATE_AUTOCRYPT_PEER =
+        public const val ACTION_UPDATE_AUTOCRYPT_PEER: String =
             "org.openintents.openpgp.action.UPDATE_AUTOCRYPT_PEER"
 
         /* Intent extras */
-        const val EXTRA_API_VERSION = "api_version"
+        public const val EXTRA_API_VERSION: String = "api_version"
 
         // ACTION_DETACHED_SIGN, ENCRYPT, SIGN_AND_ENCRYPT, DECRYPT_VERIFY
         // request ASCII Armor for output
         // OpenPGP Radix-64, 33 percent overhead compared to binary, see http://tools.ietf.org/html/rfc4880#page-53)
-        const val EXTRA_REQUEST_ASCII_ARMOR = "ascii_armor"
+        public const val EXTRA_REQUEST_ASCII_ARMOR: String = "ascii_armor"
 
         // ACTION_DETACHED_SIGN
-        const val RESULT_DETACHED_SIGNATURE = "detached_signature"
-        const val RESULT_SIGNATURE_MICALG = "signature_micalg"
+        public const val RESULT_DETACHED_SIGNATURE: String = "detached_signature"
+        public const val RESULT_SIGNATURE_MICALG: String = "signature_micalg"
 
         // ENCRYPT, SIGN_AND_ENCRYPT, QUERY_AUTOCRYPT_STATUS
-        const val EXTRA_USER_IDS = "user_ids"
-        const val EXTRA_KEY_IDS = "key_ids"
-        const val EXTRA_KEY_IDS_SELECTED = "key_ids_selected"
-        const val EXTRA_SIGN_KEY_ID = "sign_key_id"
+        public const val EXTRA_USER_IDS: String = "user_ids"
+        public const val EXTRA_KEY_IDS: String = "key_ids"
+        public const val EXTRA_KEY_IDS_SELECTED: String = "key_ids_selected"
+        public const val EXTRA_SIGN_KEY_ID: String = "sign_key_id"
 
-        const val RESULT_KEYS_CONFIRMED = "keys_confirmed"
-        const val RESULT_AUTOCRYPT_STATUS = "autocrypt_status"
-        const val AUTOCRYPT_STATUS_UNAVAILABLE = 0
-        const val AUTOCRYPT_STATUS_DISCOURAGE = 1
-        const val AUTOCRYPT_STATUS_AVAILABLE = 2
-        const val AUTOCRYPT_STATUS_MUTUAL = 3
+        public const val RESULT_KEYS_CONFIRMED: String = "keys_confirmed"
+        public const val RESULT_AUTOCRYPT_STATUS: String = "autocrypt_status"
+        public const val AUTOCRYPT_STATUS_UNAVAILABLE: Int = 0
+        public const val AUTOCRYPT_STATUS_DISCOURAGE: Int = 1
+        public const val AUTOCRYPT_STATUS_AVAILABLE: Int = 2
+        public const val AUTOCRYPT_STATUS_MUTUAL: Int = 3
 
         // optional extras:
-        const val EXTRA_PASSPHRASE = "passphrase"
-        const val EXTRA_ORIGINAL_FILENAME = "original_filename"
-        const val EXTRA_ENABLE_COMPRESSION = "enable_compression"
-        const val EXTRA_OPPORTUNISTIC_ENCRYPTION = "opportunistic"
+        public const val EXTRA_PASSPHRASE: String = "passphrase"
+        public const val EXTRA_ORIGINAL_FILENAME: String = "original_filename"
+        public const val EXTRA_ENABLE_COMPRESSION: String = "enable_compression"
+        public const val EXTRA_OPPORTUNISTIC_ENCRYPTION: String = "opportunistic"
 
         // GET_SIGN_KEY_ID
-        const val EXTRA_USER_ID = "user_id"
+        public const val EXTRA_USER_ID: String = "user_id"
 
         // GET_KEY
-        const val EXTRA_KEY_ID = "key_id"
-        const val EXTRA_MINIMIZE = "minimize"
-        const val EXTRA_MINIMIZE_USER_ID = "minimize_user_id"
-        const val RESULT_KEY_IDS = "key_ids"
+        public const val EXTRA_KEY_ID: String = "key_id"
+        public const val EXTRA_MINIMIZE: String = "minimize"
+        public const val EXTRA_MINIMIZE_USER_ID: String = "minimize_user_id"
+        public const val RESULT_KEY_IDS: String = "key_ids"
 
         // BACKUP
-        const val EXTRA_BACKUP_SECRET = "backup_secret"
+        public const val EXTRA_BACKUP_SECRET: String = "backup_secret"
 
         /* Service Intent returns */
-        const val RESULT_CODE = "result_code"
+        public const val RESULT_CODE: String = "result_code"
 
         // get actual error object from RESULT_ERROR
-        const val RESULT_CODE_ERROR = 0
+        public const val RESULT_CODE_ERROR: Int = 0
 
         // success!
-        const val RESULT_CODE_SUCCESS = 1
+        public const val RESULT_CODE_SUCCESS: Int = 1
 
         // get PendingIntent from RESULT_INTENT, start PendingIntent with startIntentSenderForResult,
         // and execute service method again in onActivityResult
-        const val RESULT_CODE_USER_INTERACTION_REQUIRED = 2
+        public const val RESULT_CODE_USER_INTERACTION_REQUIRED: Int = 2
 
-        const val RESULT_ERROR = "error"
-        const val RESULT_INTENT = "intent"
+        public const val RESULT_ERROR: String = "error"
+        public const val RESULT_INTENT: String = "intent"
 
         // DECRYPT_VERIFY
-        const val EXTRA_DETACHED_SIGNATURE = "detached_signature"
-        const val EXTRA_PROGRESS_MESSENGER = "progress_messenger"
-        const val EXTRA_DATA_LENGTH = "data_length"
-        const val EXTRA_DECRYPTION_RESULT = "decryption_result"
-        const val EXTRA_SENDER_ADDRESS = "sender_address"
-        const val EXTRA_SUPPORT_OVERRIDE_CRYPTO_WARNING = "support_override_crpto_warning"
-        const val EXTRA_AUTOCRYPT_PEER_ID = "autocrypt_peer_id"
-        const val EXTRA_AUTOCRYPT_PEER_UPDATE = "autocrypt_peer_update"
-        const val EXTRA_AUTOCRYPT_PEER_GOSSIP_UPDATES = "autocrypt_peer_gossip_updates"
-        const val RESULT_SIGNATURE = "signature"
-        const val RESULT_DECRYPTION = "decryption"
-        const val RESULT_METADATA = "metadata"
-        const val RESULT_INSECURE_DETAIL_INTENT = "insecure_detail_intent"
-        const val RESULT_OVERRIDE_CRYPTO_WARNING = "override_crypto_warning"
+        public const val EXTRA_DETACHED_SIGNATURE: String = "detached_signature"
+        public const val EXTRA_PROGRESS_MESSENGER: String = "progress_messenger"
+        public const val EXTRA_DATA_LENGTH: String = "data_length"
+        public const val EXTRA_DECRYPTION_RESULT: String = "decryption_result"
+        public const val EXTRA_SENDER_ADDRESS: String = "sender_address"
+        public const val EXTRA_SUPPORT_OVERRIDE_CRYPTO_WARNING: String = "support_override_crpto_warning"
+        public const val EXTRA_AUTOCRYPT_PEER_ID: String = "autocrypt_peer_id"
+        public const val EXTRA_AUTOCRYPT_PEER_UPDATE: String = "autocrypt_peer_update"
+        public const val EXTRA_AUTOCRYPT_PEER_GOSSIP_UPDATES: String = "autocrypt_peer_gossip_updates"
+        public const val RESULT_SIGNATURE: String = "signature"
+        public const val RESULT_DECRYPTION: String = "decryption"
+        public const val RESULT_METADATA: String = "metadata"
+        public const val RESULT_INSECURE_DETAIL_INTENT: String = "insecure_detail_intent"
+        public const val RESULT_OVERRIDE_CRYPTO_WARNING: String = "override_crypto_warning"
 
         // This will be the charset which was specified in the headers of ascii armored input, if any
-        const val RESULT_CHARSET = "charset"
+        public const val RESULT_CHARSET: String = "charset"
 
         // INTERNAL, must not be used
-        const val EXTRA_CALL_UUID1 = "call_uuid1"
-        const val EXTRA_CALL_UUID2 = "call_uuid2"
+        internal const val EXTRA_CALL_UUID1 = "call_uuid1"
+        internal const val EXTRA_CALL_UUID2 = "call_uuid2"
     }
 }

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpServiceConnection.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpServiceConnection.kt
@@ -15,6 +15,7 @@ public class OpenPgpServiceConnection(context: Context, providerPackageName: Str
 
     // callback interface
     public interface OnBound {
+
         public fun onBound(service: IOpenPgpService2)
         public fun onError(e: Exception)
     }

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpServiceConnection.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpServiceConnection.kt
@@ -11,16 +11,16 @@ import android.content.ServiceConnection
 import android.os.IBinder
 import org.openintents.openpgp.IOpenPgpService2
 
-class OpenPgpServiceConnection(context: Context, providerPackageName: String?) {
+public class OpenPgpServiceConnection(context: Context, providerPackageName: String?) {
 
     // callback interface
-    interface OnBound {
-        fun onBound(service: IOpenPgpService2)
-        fun onError(e: Exception)
+    public interface OnBound {
+        public fun onBound(service: IOpenPgpService2)
+        public fun onError(e: Exception)
     }
 
     private val mApplicationContext: Context = context.applicationContext
-    var service: IOpenPgpService2? = null
+    public var service: IOpenPgpService2? = null
         private set
     private val mProviderPackageName: String? = providerPackageName
     private var mOnBoundListener: OnBound? = null
@@ -33,7 +33,7 @@ class OpenPgpServiceConnection(context: Context, providerPackageName: String?) {
      * e.g., "org.sufficientlysecure.keychain"
      * @param onBoundListener callback, executed when connection to service has been established
      */
-    constructor(
+    public constructor(
         context: Context,
         providerPackageName: String?,
         onBoundListener: OnBound?
@@ -41,7 +41,7 @@ class OpenPgpServiceConnection(context: Context, providerPackageName: String?) {
         mOnBoundListener = onBoundListener
     }
 
-    val isBound: Boolean
+    public val isBound: Boolean
         get() = service != null
 
     private val mServiceConnection: ServiceConnection = object : ServiceConnection {
@@ -57,10 +57,8 @@ class OpenPgpServiceConnection(context: Context, providerPackageName: String?) {
 
     /**
      * If not already bound, bind to service!
-     *
-     * @return
      */
-    fun bindToService() {
+    public fun bindToService() {
         if (service == null) {
             // if not already bound...
             try {
@@ -83,7 +81,7 @@ class OpenPgpServiceConnection(context: Context, providerPackageName: String?) {
         }
     }
 
-    fun unbindFromService() {
+    public fun unbindFromService() {
         mApplicationContext.unbindService(mServiceConnection)
     }
 }

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/OpenPgpUtils.kt
@@ -11,7 +11,8 @@ import java.io.Serializable
 import java.util.Locale
 import java.util.regex.Pattern
 
-object OpenPgpUtils {
+public object OpenPgpUtils {
+
     private val PGP_MESSAGE: Pattern = Pattern.compile(
         ".*?(-----BEGIN PGP MESSAGE-----.*?-----END PGP MESSAGE-----).*",
         Pattern.DOTALL
@@ -20,30 +21,30 @@ object OpenPgpUtils {
         ".*?(-----BEGIN PGP SIGNED MESSAGE-----.*?-----BEGIN PGP SIGNATURE-----.*?-----END PGP SIGNATURE-----).*",
         Pattern.DOTALL
     )
-    const val PARSE_RESULT_NO_PGP = -1
-    const val PARSE_RESULT_MESSAGE = 0
-    const val PARSE_RESULT_SIGNED_MESSAGE = 1
+    private val USER_ID_PATTERN = Pattern.compile("^(.*?)(?: \\((.*)\\))?(?: <(.*)>)?$")
+    private val EMAIL_PATTERN = Pattern.compile("^<?\"?([^<>\"]*@[^<>\"]*\\.[^<>\"]*)\"?>?$")
+    public const val PARSE_RESULT_NO_PGP: Int = -1
+    public const val PARSE_RESULT_MESSAGE: Int = 0
+    public const val PARSE_RESULT_SIGNED_MESSAGE: Int = 1
 
-    fun parseMessage(message: String): Int {
+    public fun parseMessage(message: String): Int {
         val matcherSigned = PGP_SIGNED_MESSAGE.matcher(message)
         val matcherMessage = PGP_MESSAGE.matcher(message)
-        return if (matcherMessage.matches()) {
-            PARSE_RESULT_MESSAGE
-        } else if (matcherSigned.matches()) {
-            PARSE_RESULT_SIGNED_MESSAGE
-        } else {
-            PARSE_RESULT_NO_PGP
+        return when {
+            matcherMessage.matches() -> PARSE_RESULT_MESSAGE
+            matcherSigned.matches() -> PARSE_RESULT_SIGNED_MESSAGE
+            else -> PARSE_RESULT_NO_PGP
         }
     }
 
-    fun isAvailable(context: Context): Boolean {
+    public fun isAvailable(context: Context): Boolean {
         val intent = Intent(OpenPgpApi.SERVICE_INTENT_2)
         val resInfo =
             context.packageManager.queryIntentServices(intent, 0)
         return resInfo.isNotEmpty()
     }
 
-    fun convertKeyIdToHex(keyId: Long): String {
+    public fun convertKeyIdToHex(keyId: Long): String {
         return "0x" + convertKeyIdToHex32bit(keyId shr 32) + convertKeyIdToHex32bit(
             keyId
         )
@@ -58,15 +59,11 @@ object OpenPgpUtils {
         return hexString
     }
 
-    private val USER_ID_PATTERN = Pattern.compile("^(.*?)(?: \\((.*)\\))?(?: <(.*)>)?$")
-    private val EMAIL_PATTERN =
-        Pattern.compile("^<?\"?([^<>\"]*@[^<>\"]*\\.[^<>\"]*)\"?>?$")
-
     /**
      * Splits userId string into naming part, email part, and comment part.
      * See SplitUserIdTest for examples.
      */
-    fun splitUserId(userId: String): UserId {
+    public fun splitUserId(userId: String): UserId {
         if (!TextUtils.isEmpty(userId)) {
             val matcher = USER_ID_PATTERN.matcher(userId)
             if (matcher.matches()) {
@@ -96,7 +93,7 @@ object OpenPgpUtils {
     /**
      * Returns a composed user id. Returns null if name, email and comment are empty.
      */
-    fun createUserId(userId: UserId): String? {
+    public fun createUserId(userId: UserId): String? {
         val userIdBuilder = StringBuilder()
         if (!TextUtils.isEmpty(userId.name)) {
             userIdBuilder.append(userId.name)
@@ -114,6 +111,5 @@ object OpenPgpUtils {
         return if (userIdBuilder.isEmpty()) null else userIdBuilder.toString()
     }
 
-    class UserId(val name: String?, val email: String?, val comment: String?) :
-        Serializable
+    public class UserId(public val name: String?, public val email: String?, public val comment: String?) : Serializable
 }

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ParcelFileDescriptorUtil.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ParcelFileDescriptorUtil.kt
@@ -12,11 +12,11 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 
-object ParcelFileDescriptorUtil {
+internal object ParcelFileDescriptorUtil {
     private const val TAG = "PFDUtils"
 
     @Throws(IOException::class)
-    fun pipeFrom(inputStream: InputStream): ParcelFileDescriptor {
+    internal fun pipeFrom(inputStream: InputStream): ParcelFileDescriptor {
         val pipe = ParcelFileDescriptor.createPipe()
         val readSide = pipe[0]
         val writeSide = pipe[1]
@@ -26,14 +26,13 @@ object ParcelFileDescriptorUtil {
     }
 
     @Throws(IOException::class)
-    fun pipeTo(outputStream: OutputStream, output: ParcelFileDescriptor?): TransferThread {
+    internal fun pipeTo(outputStream: OutputStream, output: ParcelFileDescriptor?): TransferThread {
         val t = TransferThread(AutoCloseInputStream(output), outputStream)
         t.start()
         return t
     }
 
-    class TransferThread(val `in`: InputStream, private val out: OutputStream) :
-        Thread("IPC Transfer Thread") {
+    internal class TransferThread(val `in`: InputStream, private val out: OutputStream) : Thread("IPC Transfer Thread") {
         override fun run() {
             val buf = ByteArray(4096)
             var len: Int

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ParcelFileDescriptorUtil.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ParcelFileDescriptorUtil.kt
@@ -13,6 +13,7 @@ import java.io.InputStream
 import java.io.OutputStream
 
 internal object ParcelFileDescriptorUtil {
+
     private const val TAG = "PFDUtils"
 
     @Throws(IOException::class)
@@ -33,6 +34,7 @@ internal object ParcelFileDescriptorUtil {
     }
 
     internal class TransferThread(val `in`: InputStream, private val out: OutputStream) : Thread("IPC Transfer Thread") {
+
         override fun run() {
             val buf = ByteArray(4096)
             var len: Int

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ProviderUtils.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ProviderUtils.kt
@@ -11,7 +11,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import me.msfjarvis.openpgpktx.R
 import me.msfjarvis.openpgpktx.model.OpenPgpProviderEntry
 
-object ProviderUtils {
+internal object ProviderUtils {
     private const val OPENKEYCHAIN_PACKAGE = "org.sufficientlysecure.keychain"
     private const val MARKET_INTENT_URI_BASE = "market://details?id=%s"
     private const val PACKAGE_NAME_APG = "org.thialfihar.android.apg"
@@ -25,7 +25,7 @@ object ProviderUtils {
         )
     )
 
-    fun getAppList(context: Context): ArrayList<OpenPgpProviderEntry> {
+    internal fun getAppList(context: Context): ArrayList<OpenPgpProviderEntry> {
         val apps = ArrayList<OpenPgpProviderEntry>()
 
         // Add the 'None' option

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ProviderUtils.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/ProviderUtils.kt
@@ -12,18 +12,12 @@ import me.msfjarvis.openpgpktx.R
 import me.msfjarvis.openpgpktx.model.OpenPgpProviderEntry
 
 internal object ProviderUtils {
+
     private const val OPENKEYCHAIN_PACKAGE = "org.sufficientlysecure.keychain"
     private const val MARKET_INTENT_URI_BASE = "market://details?id=%s"
     private const val PACKAGE_NAME_APG = "org.thialfihar.android.apg"
     private val PROVIDER_BLACKLIST = arrayOf(PACKAGE_NAME_APG)
-    private val MARKET_INTENT = Intent(
-        Intent.ACTION_VIEW, Uri.parse(
-            String.format(
-                MARKET_INTENT_URI_BASE,
-                OPENKEYCHAIN_PACKAGE
-            )
-        )
-    )
+    private val MARKET_INTENT = Intent(Intent.ACTION_VIEW, Uri.parse(String.format(MARKET_INTENT_URI_BASE, OPENKEYCHAIN_PACKAGE)))
 
     internal fun getAppList(context: Context): ArrayList<OpenPgpProviderEntry> {
         val apps = ArrayList<OpenPgpProviderEntry>()

--- a/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/TypedArrayUtils.kt
+++ b/library/src/main/kotlin/me/msfjarvis/openpgpktx/util/TypedArrayUtils.kt
@@ -11,7 +11,7 @@ import android.util.TypedValue
  * @return The resource ID value in the `context` specified by `attr`. If it does
  * not exist, `fallbackAttr`.
  */
-fun getAttr(context: Context, attr: Int, fallbackAttr: Int): Int {
+internal fun getAttr(context: Context, attr: Int, fallbackAttr: Int): Int {
     val value = TypedValue()
     context.theme.resolveAttribute(attr, value, true)
     return if (value.resourceId != 0) {

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpDecryptionResult.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpDecryptionResult.kt
@@ -10,18 +10,18 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
 
-class OpenPgpDecryptionResult() : Parcelable {
+public class OpenPgpDecryptionResult() : Parcelable {
     private var result = 0
     private var sessionKey: ByteArray? = null
     private var decryptedSessionKey: ByteArray? = null
 
-    constructor(result: Int) : this() {
+    private constructor(result: Int) : this() {
         this.result = result
         sessionKey = null
         decryptedSessionKey = null
     }
 
-    constructor(
+    private constructor(
         result: Int,
         sessionKey: ByteArray?,
         decryptedSessionKey: ByteArray?
@@ -34,21 +34,21 @@ class OpenPgpDecryptionResult() : Parcelable {
         this.decryptedSessionKey = decryptedSessionKey
     }
 
-    fun getResult(): Int {
+    public fun getResult(): Int {
         return result
     }
 
-    fun hasDecryptedSessionKey(): Boolean {
+    public fun hasDecryptedSessionKey(): Boolean {
         return sessionKey != null
     }
 
-    fun getSessionKey(): ByteArray? {
+    public fun getSessionKey(): ByteArray? {
         return if (sessionKey == null) {
             null
         } else sessionKey!!.copyOf(sessionKey!!.size)
     }
 
-    fun getDecryptedSessionKey(): ByteArray? {
+    public fun getDecryptedSessionKey(): ByteArray? {
         return if (sessionKey == null || decryptedSessionKey == null) {
             null
         } else decryptedSessionKey!!.copyOf(decryptedSessionKey!!.size)
@@ -85,7 +85,7 @@ class OpenPgpDecryptionResult() : Parcelable {
         return "\nresult: $result"
     }
 
-    companion object CREATOR : Creator<OpenPgpDecryptionResult> {
+    private companion object CREATOR : Creator<OpenPgpDecryptionResult> {
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpDecryptionResult.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpDecryptionResult.kt
@@ -11,6 +11,7 @@ import android.os.Parcelable
 import android.os.Parcelable.Creator
 
 public class OpenPgpDecryptionResult() : Parcelable {
+
     private var result = 0
     private var sessionKey: ByteArray? = null
     private var decryptedSessionKey: ByteArray? = null
@@ -86,6 +87,7 @@ public class OpenPgpDecryptionResult() : Parcelable {
     }
 
     private companion object CREATOR : Creator<OpenPgpDecryptionResult> {
+
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpDecryptionResult.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpDecryptionResult.kt
@@ -86,23 +86,24 @@ public class OpenPgpDecryptionResult() : Parcelable {
         return "\nresult: $result"
     }
 
-    private companion object CREATOR : Creator<OpenPgpDecryptionResult> {
+    public companion object CREATOR : Creator<OpenPgpDecryptionResult> {
 
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning
          * system for the parcels sent between the clients and the providers.
          */
-        const val PARCELABLE_VERSION = 2
+        private const val PARCELABLE_VERSION  = 2
 
         // content not encrypted
-        const val RESULT_NOT_ENCRYPTED = -1
+        public const val RESULT_NOT_ENCRYPTED: Int  = -1
 
         // insecure!
-        const val RESULT_INSECURE = 0
+        public const val RESULT_INSECURE: Int  = 0
 
         // encrypted
-        const val RESULT_ENCRYPTED = 1
+        public const val RESULT_ENCRYPTED: Int  = 1
+
         override fun createFromParcel(source: Parcel): OpenPgpDecryptionResult? {
             val version = source.readInt() // parcelableVersion
             val parcelableSize = source.readInt()

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpError.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpError.kt
@@ -55,22 +55,22 @@ public class OpenPgpError() : Parcelable {
         dest.setDataPosition(startPosition + parcelableSize)
     }
 
-    internal companion object CREATOR : Creator<OpenPgpError> {
+    public companion object CREATOR : Creator<OpenPgpError> {
 
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning
          * system for the parcels sent between the clients and the providers.
          */
-        const val PARCELABLE_VERSION = 1
+        private const val PARCELABLE_VERSION = 1
 
         // possible values for errorId
-        const val CLIENT_SIDE_ERROR = -1
-        const val GENERIC_ERROR = 0
-        const val INCOMPATIBLE_API_VERSIONS = 1
-        const val NO_OR_WRONG_PASSPHRASE = 2
-        const val NO_USER_IDS = 3
-        const val OPPORTUNISTIC_MISSING_KEYS = 4
+        public const val CLIENT_SIDE_ERROR: Int = -1
+        public const val GENERIC_ERROR: Int = 0
+        public const val INCOMPATIBLE_API_VERSIONS: Int = 1
+        public const val NO_OR_WRONG_PASSPHRASE: Int = 2
+        public const val NO_USER_IDS: Int = 3
+        public const val OPPORTUNISTIC_MISSING_KEYS: Int = 4
 
         override fun createFromParcel(source: Parcel): OpenPgpError? {
             source.readInt() // parcelableVersion

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpError.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpError.kt
@@ -10,21 +10,21 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
 
-class OpenPgpError() : Parcelable {
-    var errorId = 0
-    var message: String? = null
+public class OpenPgpError() : Parcelable {
+    public var errorId: Int = 0
+    public var message: String? = null
 
-    constructor(parcel: Parcel) : this() {
+    private constructor(parcel: Parcel) : this() {
         errorId = parcel.readInt()
         message = parcel.readString()
     }
 
-    constructor(errorId: Int, message: String?) : this() {
+    internal constructor(errorId: Int, message: String?) : this() {
         this.errorId = errorId
         this.message = message
     }
 
-    constructor(b: OpenPgpError) : this() {
+    internal constructor(b: OpenPgpError) : this() {
         errorId = b.errorId
         message = b.message
     }
@@ -36,7 +36,7 @@ class OpenPgpError() : Parcelable {
     override fun writeToParcel(dest: Parcel, flags: Int) {
         /**
          * NOTE: When adding fields in the process of updating this API, make sure to bump
-         * [.PARCELABLE_VERSION].
+         * [PARCELABLE_VERSION].
          */
         dest.writeInt(PARCELABLE_VERSION)
         // Inject a placeholder that will store the parcel size from this point on
@@ -54,7 +54,7 @@ class OpenPgpError() : Parcelable {
         dest.setDataPosition(startPosition + parcelableSize)
     }
 
-    companion object CREATOR : Creator<OpenPgpError> {
+    internal companion object CREATOR : Creator<OpenPgpError> {
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpError.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpError.kt
@@ -11,6 +11,7 @@ import android.os.Parcelable
 import android.os.Parcelable.Creator
 
 public class OpenPgpError() : Parcelable {
+
     public var errorId: Int = 0
     public var message: String? = null
 
@@ -55,6 +56,7 @@ public class OpenPgpError() : Parcelable {
     }
 
     internal companion object CREATOR : Creator<OpenPgpError> {
+
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpMetadata.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpMetadata.kt
@@ -81,6 +81,7 @@ public class OpenPgpMetadata() : Parcelable {
     }
 
     private companion object CREATOR : Creator<OpenPgpMetadata> {
+
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpMetadata.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpMetadata.kt
@@ -80,14 +80,15 @@ public class OpenPgpMetadata() : Parcelable {
         dest.setDataPosition(startPosition + parcelableSize)
     }
 
-    private companion object CREATOR : Creator<OpenPgpMetadata> {
+    public companion object CREATOR : Creator<OpenPgpMetadata> {
 
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning
          * system for the parcels sent between the clients and the providers.
          */
-        const val PARCELABLE_VERSION = 2
+        private const val PARCELABLE_VERSION = 2
+
         override fun createFromParcel(source: Parcel): OpenPgpMetadata? {
             val version = source.readInt() // parcelableVersion
             val parcelableSize = source.readInt()

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpMetadata.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpMetadata.kt
@@ -10,15 +10,15 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
 
-class OpenPgpMetadata() : Parcelable {
+public class OpenPgpMetadata() : Parcelable {
 
-    var filename: String? = null
-    var mimeType: String? = null
-    var charset: String? = null
-    var modificationTime: Long = 0
-    var originalSize: Long = 0
+    public var filename: String? = null
+    public var mimeType: String? = null
+    public var charset: String? = null
+    public var modificationTime: Long = 0
+    public var originalSize: Long = 0
 
-    constructor(
+    private constructor(
         filename: String?,
         mimeType: String?,
         modificationTime: Long,
@@ -32,7 +32,7 @@ class OpenPgpMetadata() : Parcelable {
         this.charset = charset
     }
 
-    constructor(
+    private constructor(
         filename: String?,
         mimeType: String?,
         modificationTime: Long,
@@ -44,7 +44,7 @@ class OpenPgpMetadata() : Parcelable {
         this.originalSize = originalSize
     }
 
-    constructor(b: OpenPgpMetadata) : this() {
+    private constructor(b: OpenPgpMetadata) : this() {
         filename = b.filename
         mimeType = b.mimeType
         modificationTime = b.modificationTime
@@ -58,7 +58,7 @@ class OpenPgpMetadata() : Parcelable {
     override fun writeToParcel(dest: Parcel, flags: Int) {
         /**
          * NOTE: When adding fields in the process of updating this API, make sure to bump
-         * [.PARCELABLE_VERSION].
+         * [PARCELABLE_VERSION].
          */
         dest.writeInt(PARCELABLE_VERSION)
         // Inject a placeholder that will store the parcel size from this point on
@@ -80,7 +80,7 @@ class OpenPgpMetadata() : Parcelable {
         dest.setDataPosition(startPosition + parcelableSize)
     }
 
-    companion object CREATOR : Creator<OpenPgpMetadata> {
+    private companion object CREATOR : Creator<OpenPgpMetadata> {
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpSignatureResult.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpSignatureResult.kt
@@ -9,10 +9,11 @@ package org.openintents.openpgp
 import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
-import me.msfjarvis.openpgpktx.util.OpenPgpUtils
 import java.util.Date
+import me.msfjarvis.openpgpktx.util.OpenPgpUtils
 
 public class OpenPgpSignatureResult : Parcelable {
+
     private val result: Int
     private val keyId: Long
     private val primaryUserId: String?
@@ -164,6 +165,7 @@ public class OpenPgpSignatureResult : Parcelable {
     }
 
     private companion object CREATOR : Creator<OpenPgpSignatureResult> {
+
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpSignatureResult.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpSignatureResult.kt
@@ -10,10 +10,9 @@ import android.os.Parcel
 import android.os.Parcelable
 import android.os.Parcelable.Creator
 import me.msfjarvis.openpgpktx.util.OpenPgpUtils
-import java.util.Collections
 import java.util.Date
 
-class OpenPgpSignatureResult : Parcelable {
+public class OpenPgpSignatureResult : Parcelable {
     private val result: Int
     private val keyId: Long
     private val primaryUserId: String?
@@ -59,7 +58,7 @@ class OpenPgpSignatureResult : Parcelable {
         if (version > 2) {
             senderStatusResult = readEnumWithNullAndFallback(
                 source,
-                SenderStatusResult.values,
+                SenderStatusResult.values(),
                 SenderStatusResult.UNKNOWN
             )
             confirmedUserIds = source.createStringArrayList()
@@ -75,7 +74,7 @@ class OpenPgpSignatureResult : Parcelable {
         autocryptPeerentityResult = if (version > 4) {
             readEnumWithNullAndFallback(
                 source,
-                AutocryptPeerResult.values,
+                AutocryptPeerResult.values(),
                 null
             )
         } else {
@@ -83,12 +82,12 @@ class OpenPgpSignatureResult : Parcelable {
         }
     }
 
-    fun getUserIds(): List<String> {
-        return Collections.unmodifiableList(userIds)
+    public fun getUserIds(): List<String> {
+        return (userIds ?: arrayListOf()).toList()
     }
 
-    fun getConfirmedUserIds(): List<String> {
-        return Collections.unmodifiableList(confirmedUserIds)
+    public fun getConfirmedUserIds(): List<String> {
+        return (confirmedUserIds ?: arrayListOf()).toList()
     }
 
     override fun describeContents(): Int {
@@ -142,39 +141,29 @@ class OpenPgpSignatureResult : Parcelable {
     }
 
     @Deprecated("")
-    fun withSignatureOnlyFlag(signatureOnly: Boolean): OpenPgpSignatureResult {
+    public fun withSignatureOnlyFlag(signatureOnly: Boolean): OpenPgpSignatureResult {
         return OpenPgpSignatureResult(
             result, primaryUserId, keyId, userIds, confirmedUserIds,
             senderStatusResult, signatureOnly, signatureTimestamp, autocryptPeerentityResult
         )
     }
 
-    fun withAutocryptPeerResult(autocryptPeerentityResult: AutocryptPeerResult?): OpenPgpSignatureResult {
+    public fun withAutocryptPeerResult(autocryptPeerentityResult: AutocryptPeerResult?): OpenPgpSignatureResult {
         return OpenPgpSignatureResult(
             result, primaryUserId, keyId, userIds, confirmedUserIds,
             senderStatusResult, null, signatureTimestamp, autocryptPeerentityResult
         )
     }
 
-    enum class SenderStatusResult {
+    public enum class SenderStatusResult {
         UNKNOWN, USER_ID_CONFIRMED, USER_ID_UNCONFIRMED, USER_ID_MISSING;
-
-        companion object {
-            val values =
-                values()
-        }
     }
 
-    enum class AutocryptPeerResult {
+    public enum class AutocryptPeerResult {
         OK, NEW, MISMATCH;
-
-        companion object {
-            val values =
-                values()
-        }
     }
 
-    companion object CREATOR : Creator<OpenPgpSignatureResult> {
+    private companion object CREATOR : Creator<OpenPgpSignatureResult> {
         /**
          * Since there might be a case where new versions of the client using the library getting
          * old versions of the protocol (and thus old versions of this class), we need a versioning

--- a/library/src/main/kotlin/org/openintents/openpgp/OpenPgpSignatureResult.kt
+++ b/library/src/main/kotlin/org/openintents/openpgp/OpenPgpSignatureResult.kt
@@ -164,7 +164,7 @@ public class OpenPgpSignatureResult : Parcelable {
         OK, NEW, MISMATCH;
     }
 
-    private companion object CREATOR : Creator<OpenPgpSignatureResult> {
+    public companion object CREATOR : Creator<OpenPgpSignatureResult> {
 
         /**
          * Since there might be a case where new versions of the client using the library getting
@@ -174,28 +174,28 @@ public class OpenPgpSignatureResult : Parcelable {
         private const val PARCELABLE_VERSION = 5
 
         // content not signed
-        const val RESULT_NO_SIGNATURE = -1
+        public const val RESULT_NO_SIGNATURE: Int = -1
 
         // invalid signature!
-        const val RESULT_INVALID_SIGNATURE = 0
+        public const val RESULT_INVALID_SIGNATURE: Int = 0
 
         // successfully verified signature, with confirmed key
-        const val RESULT_VALID_KEY_CONFIRMED = 1
+        public const val RESULT_VALID_KEY_CONFIRMED: Int = 1
 
         // no key was found for this signature verification
-        const val RESULT_KEY_MISSING = 2
+        public const val RESULT_KEY_MISSING: Int = 2
 
         // successfully verified signature, but with unconfirmed key
-        const val RESULT_VALID_KEY_UNCONFIRMED = 3
+        public const val RESULT_VALID_KEY_UNCONFIRMED: Int = 3
 
         // key has been revoked -> invalid signature!
-        const val RESULT_INVALID_KEY_REVOKED = 4
+        public const val RESULT_INVALID_KEY_REVOKED: Int = 4
 
         // key is expired -> invalid signature!
-        const val RESULT_INVALID_KEY_EXPIRED = 5
+        public const val RESULT_INVALID_KEY_EXPIRED: Int = 5
 
         // insecure cryptographic algorithms/protocol -> invalid signature!
-        const val RESULT_INVALID_KEY_INSECURE = 6
+        public const val RESULT_INVALID_KEY_INSECURE: Int = 6
 
         override fun createFromParcel(source: Parcel): OpenPgpSignatureResult? {
             val version = source.readInt() // parcelableVersion
@@ -211,7 +211,7 @@ public class OpenPgpSignatureResult : Parcelable {
             return arrayOfNulls(size)
         }
 
-        fun createWithValidSignature(
+        public fun createWithValidSignature(
             signatureStatus: Int,
             primaryUserId: String?,
             keyId: Long,
@@ -227,7 +227,7 @@ public class OpenPgpSignatureResult : Parcelable {
             )
         }
 
-        fun createWithNoSignature(): OpenPgpSignatureResult {
+        public fun createWithNoSignature(): OpenPgpSignatureResult {
             return OpenPgpSignatureResult(
                 RESULT_NO_SIGNATURE,
                 null,
@@ -241,7 +241,7 @@ public class OpenPgpSignatureResult : Parcelable {
             )
         }
 
-        fun createWithKeyMissing(keyId: Long, signatureTimestamp: Date?): OpenPgpSignatureResult {
+        public fun createWithKeyMissing(keyId: Long, signatureTimestamp: Date?): OpenPgpSignatureResult {
             return OpenPgpSignatureResult(
                 RESULT_KEY_MISSING,
                 null,
@@ -255,7 +255,7 @@ public class OpenPgpSignatureResult : Parcelable {
             )
         }
 
-        fun createWithInvalidSignature(): OpenPgpSignatureResult {
+        public fun createWithInvalidSignature(): OpenPgpSignatureResult {
             return OpenPgpSignatureResult(
                 RESULT_INVALID_SIGNATURE,
                 null,


### PR DESCRIPTION
Turns on Kotlin 1.4's new [explicit API mode](https://github.com/Kotlin/KEEP/pull/197) and updates the entire API surface of the `library` module to comply with it. There might be mistakes here.
